### PR TITLE
コマンド実行機能の基本実装（パス解決含む）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 *.a
 
 minishell
+
+.test/

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,7 @@ CFLAGS = -Wall -Wextra -Werror
 RM = rm -f
 
 LIB_DIR = ./lib
-SRCS_DIR = ./srcs ./srcs/builtin
-
+SRCS_DIR = ./srcs ./srcs/builtin ./srcs/execution
 
 LIB = $(LIB_DIR)/lib.a -lreadline
 

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,12 @@ CFLAGS = -Wall -Wextra -Werror
 RM = rm -f
 
 LIB_DIR = ./lib
-SRCS_DIR = ./srcs
+SRCS_DIR = ./srcs ./srcs/builtin
 
 
 LIB = $(LIB_DIR)/lib.a -lreadline
 
-SRCS = $(wildcard $(SRCS_DIR)/*.c)
+SRCS = $(foreach dir,$(SRCS_DIR),$(wildcard $(dir)/*.c))
 OBJS = $(SRCS:.c=.o)
 INCLUDES = -I ./includes -I ./$(LIB_DIR)/includes
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -1,9 +1,31 @@
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
+# include "ft_printf.h"
+# include "get_next_line.h"
+# include "libft.h"
 # include <readline/history.h>
 # include <readline/readline.h>
 # include <stdio.h>
 # include <stdlib.h>
+# include <sys/types.h>
+# include <sys/wait.h>
+# include <unistd.h>
+
+// execution
+// child.c
+void	exec_if_relative_path(char **cmds, char **envp);
+void	exec_if_absolute_path(char **cmds, char **envp);
+void	execute_in_child(char **cmds, char **envp);
+
+// execute.c
+int		execute(char **cmds, char **envp);
+
+// find_path.c
+char	*search_path(char *cmd_name, char **path_list);
+char	*resolve_cmd_path(char *cmd, char *path_env);
+
+// free.c
+void	free_2d_array(void **array);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -14,18 +14,18 @@
 
 // execution
 // child.c
-void	exec_if_relative_path(char **cmds, char **envp);
-void	exec_if_absolute_path(char **cmds, char **envp);
-void	execute_in_child(char **cmds, char **envp);
+void				exec_if_relative_path(char **cmds, char **envp);
+void				exec_if_absolute_path(char **cmds, char **envp);
+void				execute_in_child(char **cmds, char **envp);
 
 // execute.c
-int		execute(char **cmds, char **envp);
+int					execute(char **cmds, char **envp);
 
 // find_path.c
-char	*search_path(char *cmd_name, char **path_list);
-char	*resolve_cmd_path(char *cmd, char *path_env);
+char				*search_path(char *cmd_name, char **path_list, char *path_tail);
+char				*resolve_cmd_path(char *cmd, char *path_env);
 
 // free.c
-void	free_2d_array(void **array);
+void				free_2d_array(void **array);
 
 #endif

--- a/srcs/execution/child_exec.c
+++ b/srcs/execution/child_exec.c
@@ -1,0 +1,60 @@
+#include "minishell.h"
+
+// 相対パスなら実行
+void	exec_if_relative_path(char **cmds, char **envp)
+{
+	if (ft_strncmp(cmds[0], "./", 2) == 0 || ft_strncmp(cmds[0], "../", 3) == 0)
+	{
+		if (access(cmds[0], F_OK) == 0)
+		{
+			if (access(cmds[0], X_OK) == 0)
+			{
+				execve(cmds[0], cmds, envp);
+				perror("minishell");
+				free_2d_array((void **)cmds);
+				exit(1);
+			}
+		}
+		perror("minishell");
+		exit(EXIT_FAILURE);
+	}
+}
+
+// 絶対パスなら実行
+void	exec_if_absolute_path(char **cmds, char **envp)
+{
+	if (access(cmds[0], F_OK) == 0)
+	{
+		if (access(cmds[0], X_OK) == 0)
+		{
+			execve(cmds[0], cmds, envp);
+			perror("minishell");
+			free_2d_array((void **)cmds);
+			exit(EXIT_FAILURE);
+		}
+	}
+	perror("minishell");
+	exit(EXIT_FAILURE);
+}
+
+// 子プロセス内でのコマンド実行
+void	execute_in_child(char **cmds, char **envp)
+{
+	char	*path_env;
+	char	*cmd_path;
+
+	exec_if_relative_path(cmds, envp);
+	path_env = getenv("PATH");
+	if (!path_env || ft_strncmp(cmds[0], "/", 1) == 0)
+		exec_if_absolute_path(cmds, envp);
+	cmd_path = resolve_cmd_path(cmds[0], path_env);
+	if (!cmd_path)
+	{
+		free_2d_array((void **)cmds);
+		exit(EXIT_FAILURE);
+	}
+	execve(cmd_path, cmds, envp);
+	perror("minishell");
+	free_2d_array((void **)cmds);
+	exit(EXIT_FAILURE);
+}

--- a/srcs/execution/execute.c
+++ b/srcs/execution/execute.c
@@ -1,0 +1,19 @@
+#include "minishell.h"
+
+int	execute(char **cmds, char **envp)
+{
+	pid_t	pid;
+	int		status;
+
+	pid = fork();
+	if (pid < 0)
+	{
+		perror("minishell");
+		free_2d_array((void **)cmds);
+		exit(EXIT_FAILURE);
+	}
+	if (pid == 0)
+		execute_in_child(cmds, envp);
+	waitpid(pid, &status, 0);
+	return (status);
+}

--- a/srcs/execution/find_path.c
+++ b/srcs/execution/find_path.c
@@ -1,0 +1,44 @@
+#include "minishell.h"
+
+// 環境変数PATHの値を一つずつ確認
+char	*search_path(char *cmd_name, char **path_list)
+{
+	char	*path;
+	char	*path_tail;
+	int		i;
+
+	i = 0;
+	while (path_list[i])
+	{
+		path_tail = ft_strjoin("/", cmd_name);
+		path = ft_strjoin(path_list[i], path_tail);
+		free(path_tail);
+		if (access(path, F_OK) == 0)
+			return (path);
+		free(path);
+		i++;
+	}
+	return (NULL);
+}
+
+// 環境変数PATHからコマンドのパスを探す
+char	*resolve_cmd_path(char *cmd, char *path_env)
+{
+	char	**path_list;
+	char	*filepath;
+
+	path_list = ft_split(path_env, ':');
+	if (!path_list)
+	{
+		perror("minishell");
+		return (NULL);
+	}
+	filepath = search_path(cmd, path_list);
+	if (!filepath)
+	{
+		ft_dprintf(STDERR_FILENO, "%s: command not found\n", cmd);
+		free_2d_array((void **)path_list);
+		return (NULL);
+	}
+	return (filepath);
+}

--- a/srcs/execution/find_path.c
+++ b/srcs/execution/find_path.c
@@ -1,42 +1,53 @@
 #include "minishell.h"
 
 // 環境変数PATHの値を一つずつ確認
-char	*search_path(char *cmd_name, char **path_list)
+char	*search_path(char *cmd_name, char **path_list, char *path_tail)
 {
 	char	*path;
-	char	*path_tail;
 	int		i;
 
 	i = 0;
 	while (path_list[i])
 	{
-		path_tail = ft_strjoin("/", cmd_name);
 		path = ft_strjoin(path_list[i], path_tail);
-		free(path_tail);
+		if (!path)
+		{
+			perror("minishell");
+			return (NULL);
+		}
 		if (access(path, F_OK) == 0)
 			return (path);
 		free(path);
 		i++;
 	}
+	ft_dprintf(STDERR_FILENO, "%s: command not found\n", cmd_name);
 	return (NULL);
 }
 
 // 環境変数PATHからコマンドのパスを探す
 char	*resolve_cmd_path(char *cmd, char *path_env)
 {
+	char	*path_tail;
 	char	**path_list;
 	char	*filepath;
 
-	path_list = ft_split(path_env, ':');
-	if (!path_list)
+	path_tail = ft_strjoin("/", cmd);
+	if (!path_tail)
 	{
 		perror("minishell");
 		return (NULL);
 	}
-	filepath = search_path(cmd, path_list);
+	path_list = ft_split(path_env, ':');
+	if (!path_list)
+	{
+		perror("minishell");
+		free(path_tail);
+		return (NULL);
+	}
+	filepath = search_path(cmd, path_list, path_tail);
 	if (!filepath)
 	{
-		ft_dprintf(STDERR_FILENO, "%s: command not found\n", cmd);
+		free(path_tail);
 		free_2d_array((void **)path_list);
 		return (NULL);
 	}

--- a/srcs/free.c
+++ b/srcs/free.c
@@ -1,0 +1,16 @@
+#include "minishell.h"
+
+void	free_2d_array(void **array)
+{
+	int	i;
+
+	if (!array)
+		return ;
+	i = 0;
+	while (array[i])
+	{
+		free(array[i]);
+		i++;
+	}
+	free(array);
+}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,19 +1,35 @@
 #include "minishell.h"
 
-int	main(void)
+int	main(int argc, char **argv, char **envp)
 {
 	char	*input;
+	char	**cmds;
 
+	// TODO: あとで消す(かも)
+	(void)argc;
+	(void)argv;
 	input = NULL;
+	cmds = NULL;
 	while (1)
 	{
 		input = readline("minishell$ ");
 		if (!input)
 			break ;
-		if (*input) // 空の文字列でなければ履歴に追加
+		if (*input)
 			add_history(input);
-		/* TODO: 入力行を実行 */
+		/* TODO: 入力行を解析 */
+		// TODO: あとで消す
+		// 仮パース
+		cmds = ft_split(input, ' ');
+		if (!cmds)
+		{
+			free(input);
+			exit(EXIT_FAILURE);
+		}
+		execute(cmds, envp);
+		// TODO: あとで消す
+		free_2d_array((void **)cmds);
 		free(input);
 	}
-	exit(0);
+	exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
- readlineで取得した入力を空白区切りで分割して子プロセスで実行（仮パースとしてft_splitを使用）
- コマンド実行において、以下の順でパス解決に対応
  1. 相対パス
  2. 絶対パス
  3. 環境変数PATHから検索
- Makefileを最新版に更新し、`execution`ディレクトリを追加

【実行例】
`minishell$ /bin/ls`
`minishell$ ls -l`

> エラー処理を呼び出し元で行い、`exit`ステータスを管理するように修正要です。一旦動く状態になったのでプルリク投げました。