### PR TITLE
Parser実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ RM = rm -f
 
 LIB_DIR = ./lib
 # TODO: debugあとで消す
-SRCS_DIR = ./srcs ./srcs/builtin ./srcs/execution ./srcs/tokenization ./srcs/init ./srcs/expansion ./srcs/utils ./debug
+SRCS_DIR = ./srcs ./srcs/builtin ./srcs/execution ./srcs/tokenization ./srcs/init ./srcs/expansion ./srcs/utils ./srcs/parsing ./debug
 
 LIB = $(LIB_DIR)/lib.a -lreadline
 

--- a/debug/debug_parser.c
+++ b/debug/debug_parser.c
@@ -1,0 +1,68 @@
+#include "minishell.h"
+#include <stdbool.h>
+
+void print_indent(int depth, bool is_last) {
+	for (int i = 0; i < depth - 1; i++) {
+		printf("│   ");
+	}
+	if (depth > 0) {
+		printf(is_last ? "└── " : "├── ");
+	}
+}
+
+void print_redir(t_redir *redir, int depth) {
+	print_indent(depth, true);
+	printf("redir: ");
+	switch (redir->kind) {
+		case REDIR_IN:
+			printf("< ");
+			break;
+		case REDIR_OUT:
+			printf("> ");
+			break;
+		case REDIR_APPEND:
+			printf(">> ");
+			break;
+		case REDIR_HEREDOC:
+			printf("<< ");
+			break;
+	}
+	printf("%s\n", redir->filename);
+}
+
+void print_ast(t_node *node, int depth) {
+	if (!node)
+		return;
+
+	if (node->kind == ND_PIPE) {
+		print_indent(depth, false);
+		printf("PIPE\n");
+
+		print_ast(node->left, depth + 1);
+		print_ast(node->right, depth + 1);
+	}
+	else if (node->kind == ND_CMD) {
+		print_indent(depth, false);
+		printf("CMD: ");
+		for (int i = 0; i < node->argc; i++) {
+			printf("%s ", node->argv[i]);
+		}
+		printf("\n");
+
+		for (int i = 0; i < node->redir_count; i++) {
+			print_redir(node->redirs[i], depth + 1);
+		}
+	}
+}
+
+
+void	debug_parser(t_node *ast)
+{
+	if (!ast)
+	{
+		printf("AST is NULL\n");
+		return ;
+	}
+
+	print_ast(ast, 0);
+}

--- a/debug/debug_parser.c
+++ b/debug/debug_parser.c
@@ -1,60 +1,58 @@
 #include "minishell.h"
 #include <stdbool.h>
 
-void print_indent(int depth, bool is_last) {
-	for (int i = 0; i < depth - 1; i++) {
+void	print_indent(int depth, bool is_last)
+{
+	for (int i = 0; i < depth - 1; i++)
 		printf("│   ");
-	}
-	if (depth > 0) {
+	if (depth > 0)
 		printf(is_last ? "└── " : "├── ");
-	}
 }
 
-void print_redir(t_redir *redir, int depth) {
+void	print_redir(t_redir *redir, int depth)
+{
 	print_indent(depth, true);
 	printf("redir: ");
-	switch (redir->kind) {
-		case REDIR_IN:
-			printf("< ");
-			break;
-		case REDIR_OUT:
-			printf("> ");
-			break;
-		case REDIR_APPEND:
-			printf(">> ");
-			break;
-		case REDIR_HEREDOC:
-			printf("<< ");
-			break;
+	switch (redir->kind)
+	{
+	case REDIR_IN:
+		printf("< ");
+		break ;
+	case REDIR_OUT:
+		printf("> ");
+		break ;
+	case REDIR_APPEND:
+		printf(">> ");
+		break ;
+	case REDIR_HEREDOC:
+		printf("<< ");
+		break ;
 	}
-	printf("%s\n", redir->filename);
+	printf("%s\n", redir->str);
 }
 
-void print_ast(t_node *node, int depth) {
+void	print_ast(t_node *node, int depth)
+{
 	if (!node)
-		return;
-
-	if (node->kind == ND_PIPE) {
+		return ;
+	if (node->kind == ND_PIPE)
+	{
 		print_indent(depth, false);
 		printf("PIPE\n");
-
-		print_ast(node->left, depth + 1);
-		print_ast(node->right, depth + 1);
+		print_ast(node->lhs, depth + 1);
+		print_ast(node->rhs, depth + 1);
 	}
-	else if (node->kind == ND_CMD) {
+	else if (node->kind == ND_CMD)
+	{
 		print_indent(depth, false);
 		printf("CMD: ");
-		for (int i = 0; i < node->argc; i++) {
+		for (int i = 0; i < node->argc; i++)
 			printf("%s ", node->argv[i]);
-		}
 		printf("\n");
-
-		for (int i = 0; i < node->redir_count; i++) {
+		for (int i = 0; i < node->redir_count; i++)
 			print_redir(node->redirs[i], depth + 1);
-		}
 	}
 }
-
 
 void	debug_parser(t_node *ast)
 {
@@ -63,6 +61,6 @@ void	debug_parser(t_node *ast)
 		printf("AST is NULL\n");
 		return ;
 	}
-
+	printf("===AST===\n");
 	print_ast(ast, 0);
 }

--- a/debug/debug_parser.c
+++ b/debug/debug_parser.c
@@ -56,11 +56,12 @@ void	print_ast(t_node *node, int depth)
 
 void	debug_parser(t_node *ast)
 {
+    printf("===AST===\n");
 	if (!ast)
 	{
 		printf("AST is NULL\n");
 		return ;
 	}
-	printf("===AST===\n");
 	print_ast(ast, 0);
+    printf("===AST END===\n");
 }

--- a/debug/debug_tokenizer.c
+++ b/debug/debug_tokenizer.c
@@ -17,11 +17,12 @@ void	print_tokens(t_token *token)
 
 void	debug_tokenizer(t_token *tokens)
 {
+    printf("===TOKENS===\n");
     if (!tokens)
     {
         printf("No tokens.\n");
         return ;
     }
-    printf("===TOKENS===\n");
     print_tokens(tokens);
+    printf("===TOKENS END===\n");
 }

--- a/debug/debug_tokenizer.c
+++ b/debug/debug_tokenizer.c
@@ -19,8 +19,9 @@ void	debug_tokenizer(t_token *tokens)
 {
     if (!tokens)
     {
-        ft_dprintf(STDERR_FILENO, "debug_tokenizer: no tokens\n");
+        printf("No tokens.\n");
         return ;
     }
+    printf("===TOKENS===\n");
     print_tokens(tokens);
 }

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -30,8 +30,8 @@ typedef struct s_token
 // 構文解析
 typedef enum e_node_kind
 {
-	ND_PIPE,
-	ND_CMD,
+	ND_PIPE, // "|"単体
+	ND_CMD,  // その他のコマンドとリダイレクト記号のまとまり
 }					t_node_kind;
 
 typedef enum s_redir_kind
@@ -45,17 +45,19 @@ typedef enum s_redir_kind
 typedef struct s_redir
 {
 	t_redir_kind	kind;
-	char			*filename;
+	char			*str;
 }					t_redir;
 
 typedef struct s_node
 {
 	t_node_kind		kind;
 	char			*value;
-	struct s_node	*left;
-	struct s_node	*right;
+	struct s_node	*lhs;
+	struct s_node	*rhs;
+	// コマンドとオプション、引数
 	char			**argv;
 	int				argc;
+	// リダイレクト
 	t_redir			**redirs;
 	int				redir_count;
 }					t_node;
@@ -106,11 +108,15 @@ char				*append_string_free(char *dst, char *src);
 // utils
 // ft_getenv.c
 char				*ft_getenv(char *name, char **envp);
+// xrealloc.c
+// void				*xrealloc(void *ptr, size_t old_size, size_t new_size);
 
 // free
 // free.c
 void				free_2d_array(char **array);
 void				free_tokens(t_token *token);
+void				free_redirs(t_redir **redirs);
+void				free_ast(t_node *ast);
 void				free_shell(t_shell *shell);
 
 // debug

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -12,6 +12,7 @@
 # include <sys/wait.h>
 # include <unistd.h>
 
+// 字句解析
 typedef enum e_token_type
 {
 	TK_RESERVED,
@@ -26,12 +27,47 @@ typedef struct s_token
 	struct s_token	*next;
 }					t_token;
 
+// 構文解析
+typedef enum e_node_kind
+{
+	ND_PIPE,
+	ND_CMD,
+}					t_node_kind;
+
+typedef enum s_redir_kind
+{
+	REDIR_IN,
+	REDIR_OUT,
+	REDIR_APPEND,
+	REDIR_HEREDOC
+}					t_redir_kind;
+
+typedef struct s_redir
+{
+	t_redir_kind	kind;
+	char			*filename;
+}					t_redir;
+
+typedef struct s_node
+{
+	t_node_kind		kind;
+	char			*value;
+	struct s_node	*left;
+	struct s_node	*right;
+	char			**argv;
+	int				argc;
+	t_redir			**redirs;
+	int				redir_count;
+}					t_node;
+
+// minishell全体
 typedef struct s_shell
 {
 	int				status;
 	// int				last_status;
 	char			**envp_cp;
 	t_token			*tokens;
+	t_node			*ast;
 }					t_shell;
 
 // init
@@ -55,10 +91,17 @@ char				*resolve_cmd_path(char *cmd, char *path_env);
 // tokenization
 // tokenize.c
 int					tokenize(char *line, t_token **tokens);
+int					is_single_metachar(char *p);
+int					is_two_metachar(char *p);
+
+// parsing
+// parse.c
+int					parse(t_token *tokens, t_node **ast);
 
 // expansion
 // expand.c
 int					expand_tokens(t_token *tokens, char **envp);
+char				*append_string_free(char *dst, char *src);
 
 // utils
 // ft_getenv.c
@@ -74,5 +117,6 @@ void				free_shell(t_shell *shell);
 // debug_tokenize.c
 void				print_tokens(t_token *token);
 void				debug_tokenizer(t_token *tokens);
+void				debug_parser(t_node *ast);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -99,7 +99,15 @@ int					is_two_metachar(char *p);
 // parsing
 // parse.c
 int					parse(t_token *tokens, t_node **ast);
-
+// new_node.c
+t_node				*new_pipe_node(t_node *lhs, t_node *rhs);
+t_node				*new_command_node(void);
+// peek.c
+int					peek_word(t_token *token);
+int					peek_redir_op(t_token *token);
+// consume.c
+int					consume_word(t_token **rest, char **redir_str);
+int					consume_reserved(t_token **rest, char *op);
 // expansion
 // expand.c
 int					expand_tokens(t_token *tokens, char **envp);

--- a/lib/libft/ft_calloc.c
+++ b/lib/libft/ft_calloc.c
@@ -20,7 +20,10 @@ void	*ft_calloc(size_t nmemb, size_t size)
 		return (NULL);
 	result = malloc(nmemb * size);
 	if (!result)
+    {
+        perror("minishell");
 		return (NULL);
+    }
 	ft_bzero(result, nmemb * size);
 	return (result);
 }

--- a/srcs/init/init.c
+++ b/srcs/init/init.c
@@ -55,5 +55,6 @@ int	init(t_shell **shell, char **envp)
 			return (-1);
 		}
 	}
+    (*shell)->ast = NULL;
 	return (0);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -35,7 +35,16 @@ int	main(int argc, char **argv, char **envp)
 		}
 		// TODO: debugあとで消す
 		debug_tokenizer(shell->tokens);
-		/* TODO: 入力行を解析 */
+        shell->status = parse(shell->tokens, &shell->ast);
+        if (shell->status < 0)
+        {
+            free(input);
+            free_shell(shell);
+            exit(EXIT_FAILURE);
+        }
+        free_tokens(shell->tokens);
+        // TODO: debugあとで消す
+        debug_parser(shell->ast);
 		// execute(tokens, envp);
 		free(input);
 	}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -45,7 +45,12 @@ int	main(int argc, char **argv, char **envp)
         // TODO: debugあとで消す
         debug_parser(shell->ast);
 		// execute(tokens, envp);
+		// 毎ループ更新されるためfree
 		free(input);
+		free_tokens(shell->tokens);
+		shell->tokens = NULL;
+		free_ast(shell->ast);
+		shell->ast = NULL;
 	}
 	free_shell(shell);
 	exit(EXIT_SUCCESS);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -42,7 +42,6 @@ int	main(int argc, char **argv, char **envp)
             free_shell(shell);
             exit(EXIT_FAILURE);
         }
-        free_tokens(shell->tokens);
         // TODO: debugあとで消す
         debug_parser(shell->ast);
 		// execute(tokens, envp);

--- a/srcs/parsing/consume.c
+++ b/srcs/parsing/consume.c
@@ -1,0 +1,39 @@
+#include "minishell.h"
+
+// トークンがTK_WORDかどうか確認して文字列を返し次のトークンに進める
+int	consume_word(t_token **rest, char **redir_str)
+{
+	t_token	*cur;
+
+	cur = *rest;
+	if (!peek_word(cur))
+	{
+		if (cur->type == TK_EOF)
+			ft_dprintf(STDERR_FILENO,
+				"minishell: syntax error near unexpected token `newline'\n");
+		else
+			ft_dprintf(STDERR_FILENO,
+				"minishell: syntax error near unexpected token `%s'\n",
+				cur->str);
+		(*redir_str) = NULL;
+		return (1);
+	}
+	(*redir_str) = ft_strdup(cur->str);
+	if (!(*redir_str))
+		return (-1);
+	*rest = cur->next;
+	return (0);
+}
+
+// トークンがTK_RESERVEDかつ指定された記号に一致するか確認して次のトークンに進める
+int	consume_reserved(t_token **rest, char *op)
+{
+	t_token	*cur;
+
+	cur = *rest;
+	if (cur->type != TK_RESERVED || ft_strncmp(cur->str, op, ft_strlen(op)
+			+ 1) != 0)
+		return (0);
+	*rest = cur->next;
+	return (1);
+}

--- a/srcs/parsing/new_node.c
+++ b/srcs/parsing/new_node.c
@@ -1,0 +1,35 @@
+#include "minishell.h"
+
+// 新しいパイプノードを作成して左右のノードを接続
+t_node	*new_pipe_node(t_node *lhs, t_node *rhs)
+{
+	t_node	*node;
+
+	node = ft_calloc(1, sizeof(t_node));
+	if (!node)
+	{
+		free_ast(lhs);
+		free_ast(rhs);
+		return (NULL);
+	}
+	node->kind = ND_PIPE;
+	node->lhs = lhs;
+	node->rhs = rhs;
+	return (node);
+}
+
+// 新しいコマンドノードを作成
+t_node	*new_command_node(void)
+{
+	t_node	*node;
+
+	node = ft_calloc(1, sizeof(t_node));
+	if (!node)
+		return (NULL);
+	node->kind = ND_CMD;
+	node->argv = NULL;
+	node->argc = 0;
+	node->redirs = NULL;
+	node->redir_count = 0;
+	return (node);
+}

--- a/srcs/parsing/parse.c
+++ b/srcs/parsing/parse.c
@@ -76,7 +76,7 @@ t_node	*parse_command(t_token **rest, int *stat)
 		if (!argv_tmp[node->argc - 1])
 		{
 			free_ast(node);
-			free_2d_array(argv_tmp);
+			free(argv_tmp);
 			(*stat) = -1;
 			return (NULL);
 		}
@@ -108,7 +108,7 @@ t_node	*parse_command(t_token **rest, int *stat)
 		if (!redirs_tmp[node->redir_count - 1])
 		{
 			free_ast(node);
-			free_redirs(redirs_tmp);
+			free(redirs_tmp);
 			return (NULL);
 		}
 		redirs_tmp[node->redir_count] = NULL;

--- a/srcs/parsing/parse.c
+++ b/srcs/parsing/parse.c
@@ -1,25 +1,13 @@
 #include "minishell.h"
 
-void	*ft_realloc(void *ptr, size_t old_size, size_t new_size)
-{
-    void	*new;
-
-    new = ft_calloc(new_size, 1);
-    if (!new)
-        return (NULL);
-    if (ptr)
-    {
-        ft_memcpy(new, ptr, old_size);
-        free(ptr);
-    }
-    return (new);
-}
-
-// トークンが予約語かつ指定された記号に一致するか確認して次のトークンに進める
+// トークンがTK_RESERVEDかつ指定された記号に一致するか確認して次のトークンに進める
 int	consume(t_token **rest, t_token *token, char *op)
 {
-	if (token->type != TK_RESERVED || ft_strncmp(token->str, op, ft_strlen(op)) != 0)
+	// TK_RESERVEDではない、または、opと異なっていればエラー
+	if (token->type != TK_RESERVED || ft_strncmp(token->str, op, ft_strlen(op)
+			+ 1) != 0)
 		return (0);
+	// トークンの残りを一つ消費
 	*rest = token->next;
 	return (1);
 }
@@ -27,6 +15,7 @@ int	consume(t_token **rest, t_token *token, char *op)
 // トークンがTK_WORDかどうか確認
 int	peek_word(t_token *token)
 {
+	// トークンがTK_WORDかどうか
 	if (token->type == TK_WORD)
 		return (1);
 	return (0);
@@ -35,28 +24,42 @@ int	peek_word(t_token *token)
 // トークンがリダイレクト演算子かどうか確認
 int	peek_redir_op(t_token *token)
 {
+	// トークンが予約語でなければエラー
 	if (token->type != TK_RESERVED)
 		return (0);
-	if (is_two_metachar(token->str) || is_single_metachar(token->str))
+	// トークンがリダイレクト記号かどうか
+	if (ft_strncmp(token->str, ">>", 3) == 0 || ft_strncmp(token->str, ">",
+			2) == 0 || ft_strncmp(token->str, "<<", 3) == 0
+		|| ft_strncmp(token->str, "<", 2) == 0)
 		return (1);
 	return (0);
 }
 
 // トークンがTK_WORDかどうか確認して文字列を返し次のトークンに進める
-char	*expect_word(t_token **rest, t_token *cur)
+int	expect_word(t_token **rest, t_token *cur, char **str)
 {
+	// トークンがTK_WORDでなければエラー
 	if (!peek_word(cur))
 	{
 		ft_dprintf(STDERR_FILENO, "parse error: expected word, but got: %s\n",
 			cur->str);
-		return (NULL);
+		(*str) = NULL;
+		return (0);
 	}
+	// トークンの残りを一つ消費
 	*rest = cur->next;
-	return (cur->str);
+	// トークンの文字列をコピー
+	(*str) = ft_strdup(cur->str);
+	if (!(*str))
+	{
+		(*str) = NULL;
+		return (0);
+	}
+	return (1);
 }
 
-// 新しいパイプノードを作成
-t_node	*new_pipe_node(t_node *left, t_node *right)
+// 新しいパイプノードを作成して左右のノードを接続
+t_node	*new_pipe_node(t_node *lhs, t_node *rhs)
 {
 	t_node	*node;
 
@@ -64,8 +67,8 @@ t_node	*new_pipe_node(t_node *left, t_node *right)
 	if (!node)
 		return (NULL);
 	node->kind = ND_PIPE;
-	node->left = left;
-	node->right = right;
+	node->lhs = lhs;
+	node->rhs = rhs;
 	return (node);
 }
 
@@ -91,6 +94,8 @@ t_redir	*parse_redir(t_token **rest, t_token *cur)
 	t_redir	*redir;
 
 	redir = ft_calloc(1, sizeof(t_redir));
+	if (!redir)
+		return (NULL);
 	if (consume(rest, cur, ">>"))
 		redir->kind = REDIR_APPEND;
 	else if (consume(rest, cur, ">"))
@@ -99,19 +104,26 @@ t_redir	*parse_redir(t_token **rest, t_token *cur)
 		redir->kind = REDIR_HEREDOC;
 	else if (consume(rest, cur, "<"))
 		redir->kind = REDIR_IN;
+	// リダイレクト記号以外ならエラー
 	else
 	{
-		ft_dprintf(STDERR_FILENO, "parse error: unexpected redirection token: %s\n",
-			cur->str);
+		ft_dprintf(STDERR_FILENO,
+					"minishell: syntax error near unexpected token \
+			`%s\n'",
+					cur->str);
+		free(redir);
 		return (NULL);
 	}
+	// 判定するトークンをリダイレクト記号の次のトークンに進める
 	cur = *rest;
-	redir->filename = expect_word(rest, cur);
-    if (!redir->filename)
-    {
-        free(redir);
-        return (NULL);
-    }
+	// リダイレクト記号の次がTK_WORD以外ならエラー
+	if (!expect_word(rest, cur, &redir->str))
+	{
+		ft_dprintf(STDERR_FILENO,
+			"minishell: syntax error near unexpected token `newline'");
+		free(redir);
+		return (NULL);
+	}
 	return (redir);
 }
 
@@ -119,46 +131,76 @@ t_redir	*parse_redir(t_token **rest, t_token *cur)
 t_node	*parse_command(t_token **rest, t_token *cur)
 {
 	t_node	*node;
+	char	**argv_tmp;
+	t_redir	**redirs_tmp;
+	int		i;
 
 	node = new_command_node();
 	if (!node)
 		return (NULL);
-    // TK_WORDがある間、argvに追加
+	// TK_WORDがある間、argvに追加
 	while (peek_word(cur))
 	{
 		node->argc++;
-		node->argv = ft_realloc(node->argv, sizeof(char *) * node->argc, sizeof(char *) * (node->argc + 1));
-		node->argv[node->argc - 1] = ft_strdup(cur->str);
-		if (!node->argv[node->argc])
+		argv_tmp = (char **)malloc(sizeof(char *) * (node->argc + 1));
+		if (!argv_tmp)
 		{
-			free(node->argv[node->argc]);
+			perror("minishell");
 			free(node);
 			return (NULL);
 		}
-		node->argv[node->argc] = NULL;
+		i = 0;
+		while (i < node->argc - 1)
+		{
+			argv_tmp[i] = node->argv[i];
+			i++;
+		}
+		argv_tmp[node->argc - 1] = ft_strdup(cur->str);
+		if (!argv_tmp[node->argc - 1])
+		{
+			free_ast(node);
+			free_2d_array(argv_tmp);
+			return (NULL);
+		}
+		argv_tmp[node->argc] = NULL;
+		free(node->argv);
+		node->argv = argv_tmp;
 		cur = cur->next;
 	}
-    // リダイレクト演算子がある間、redirsに追加
+	// リダイレクト演算子がある間、リダイレクト記号と次のTK_WORD（ファイル名かheredocのデリミタ）をredirsに追加
 	while (peek_redir_op(cur))
 	{
 		node->redir_count++;
-		node->redirs = ft_realloc(node->redirs, sizeof(t_redir *)
-        * node->redir_count, sizeof(t_redir *)
-				* (node->redir_count + 1));
-		node->redirs[node->redir_count - 1] = parse_redir(&cur, cur);
-        if (!node->redirs[node->redir_count - 1])
-        {
-            free(node->redirs[node->redir_count - 1]);
-            free(node->redirs);
-            free(node);
-            return (NULL);
-        }
-        node->redirs[node->redir_count] = NULL;
-        cur = cur->next;
+		redirs_tmp = (t_redir **)malloc(sizeof(t_redir *) * (node->redir_count
+					+ 1));
+		if (!redirs_tmp)
+		{
+			perror("minishell");
+			free(node);
+			return (NULL);
+		}
+		i = 0;
+		while (i < node->redir_count - 1)
+		{
+			redirs_tmp[i] = node->redirs[i];
+			i++;
+		}
+		redirs_tmp[node->redir_count - 1] = parse_redir(&cur, cur);
+		if (!redirs_tmp[node->redir_count - 1])
+		{
+			free_ast(node);
+			free(redirs_tmp);
+			return (NULL);
+		}
+		redirs_tmp[node->redir_count] = NULL;
+		free(node->redirs);
+		node->redirs = redirs_tmp;
 	}
+	// コマンドが空でリダイレクトもない場合はエラー
 	if (node->argc == 0 && node->redir_count == 0)
 	{
-		ft_dprintf(STDERR_FILENO, "parse error (parse_command)\n");
+		ft_dprintf(STDERR_FILENO,
+			"minishell: syntax error near unexpected token `|'\n");
 		free(node);
 		return (NULL);
 	}
@@ -170,19 +212,23 @@ t_node	*parse_command(t_token **rest, t_token *cur)
 t_node	*parse_line(t_token **rest, t_token *cur)
 {
 	t_node	*node;
-	t_node	*right;
+	t_node	*rhs;
 
+	// 最初のパイプまでを解析
 	node = parse_command(&cur, cur);
 	if (!node)
+	{
+		printf("invalid node\n");
 		return (NULL);
+	}
 	while (consume(&cur, cur, "|"))
 	{
-        // 右側のコマンドを解析
-		right = parse_command(&cur, cur);
-		if (!right)
+		// 右側のコマンドを解析
+		rhs = parse_command(&cur, cur);
+		if (!rhs)
 			return (NULL);
-        // パイプノードを作成し、それを根として左右のノードを接続
-		node = new_pipe_node(node, right);
+		// パイプノードを作成し、それを根として左右のノードを接続
+		node = new_pipe_node(node, rhs);
 		if (!node)
 			return (NULL);
 	}
@@ -193,22 +239,23 @@ t_node	*parse_line(t_token **rest, t_token *cur)
 // 構文解析
 int	parse(t_token *tokens, t_node **ast)
 {
-	// トークンの残り（tokensをfreeできるように別変数で管理）
+	// トークンの残り（引数のtokensをfreeできるように別変数で管理）
 	t_token	*rest;
 
+    // トークンがTK_EOFなら何もしない
+	if (tokens->type == TK_EOF)
+		return (0);
 	// トークンの先頭をrestに設定
 	rest = tokens;
 	// トークンを解析してASTを生成
-	*ast = parse_line(&rest, tokens);
+	(*ast) = parse_line(&rest, rest);
 	if (!(*ast))
 		return (-1);
 	// 残りのトークンがEOFでない場合はエラー
 	if (rest->type != TK_EOF)
 	{
 		ft_dprintf(STDERR_FILENO,
-					"parse error: extra token after valid input: \
-			%s\n",
-					rest->str);
+			"minishell: syntax error near unexpected token `%s'\n", rest->str);
 		return (-1);
 	}
 	return (0);

--- a/srcs/parsing/parse.c
+++ b/srcs/parsing/parse.c
@@ -1,0 +1,215 @@
+#include "minishell.h"
+
+void	*ft_realloc(void *ptr, size_t old_size, size_t new_size)
+{
+    void	*new;
+
+    new = ft_calloc(new_size, 1);
+    if (!new)
+        return (NULL);
+    if (ptr)
+    {
+        ft_memcpy(new, ptr, old_size);
+        free(ptr);
+    }
+    return (new);
+}
+
+// トークンが予約語かつ指定された記号に一致するか確認して次のトークンに進める
+int	consume(t_token **rest, t_token *token, char *op)
+{
+	if (token->type != TK_RESERVED || ft_strncmp(token->str, op, ft_strlen(op)) != 0)
+		return (0);
+	*rest = token->next;
+	return (1);
+}
+
+// トークンがTK_WORDかどうか確認
+int	peek_word(t_token *token)
+{
+	if (token->type == TK_WORD)
+		return (1);
+	return (0);
+}
+
+// トークンがリダイレクト演算子かどうか確認
+int	peek_redir_op(t_token *token)
+{
+	if (token->type != TK_RESERVED)
+		return (0);
+	if (is_two_metachar(token->str) || is_single_metachar(token->str))
+		return (1);
+	return (0);
+}
+
+// トークンがTK_WORDかどうか確認して文字列を返し次のトークンに進める
+char	*expect_word(t_token **rest, t_token *cur)
+{
+	if (!peek_word(cur))
+	{
+		ft_dprintf(STDERR_FILENO, "parse error: expected word, but got: %s\n",
+			cur->str);
+		return (NULL);
+	}
+	*rest = cur->next;
+	return (cur->str);
+}
+
+// 新しいパイプノードを作成
+t_node	*new_pipe_node(t_node *left, t_node *right)
+{
+	t_node	*node;
+
+	node = ft_calloc(1, sizeof(t_node));
+	if (!node)
+		return (NULL);
+	node->kind = ND_PIPE;
+	node->left = left;
+	node->right = right;
+	return (node);
+}
+
+// 新しいコマンドノードを作成
+t_node	*new_command_node(void)
+{
+	t_node	*node;
+
+	node = ft_calloc(1, sizeof(t_node));
+	if (!node)
+		return (NULL);
+	node->kind = ND_CMD;
+	node->argv = NULL;
+	node->argc = 0;
+	node->redirs = NULL;
+	node->redir_count = 0;
+	return (node);
+}
+
+// トークンを解析してリダイレクトノードを生成
+t_redir	*parse_redir(t_token **rest, t_token *cur)
+{
+	t_redir	*redir;
+
+	redir = ft_calloc(1, sizeof(t_redir));
+	if (consume(rest, cur, ">>"))
+		redir->kind = REDIR_APPEND;
+	else if (consume(rest, cur, ">"))
+		redir->kind = REDIR_OUT;
+	else if (consume(rest, cur, "<<"))
+		redir->kind = REDIR_HEREDOC;
+	else if (consume(rest, cur, "<"))
+		redir->kind = REDIR_IN;
+	else
+	{
+		ft_dprintf(STDERR_FILENO, "parse error: unexpected redirection token: %s\n",
+			cur->str);
+		return (NULL);
+	}
+	cur = *rest;
+	redir->filename = expect_word(rest, cur);
+    if (!redir->filename)
+    {
+        free(redir);
+        return (NULL);
+    }
+	return (redir);
+}
+
+// トークンを解析してコマンドノード（パイプ以外の部分をまとめたノード）を生成
+t_node	*parse_command(t_token **rest, t_token *cur)
+{
+	t_node	*node;
+
+	node = new_command_node();
+	if (!node)
+		return (NULL);
+    // TK_WORDがある間、argvに追加
+	while (peek_word(cur))
+	{
+		node->argc++;
+		node->argv = ft_realloc(node->argv, sizeof(char *) * node->argc, sizeof(char *) * (node->argc + 1));
+		node->argv[node->argc - 1] = ft_strdup(cur->str);
+		if (!node->argv[node->argc])
+		{
+			free(node->argv[node->argc]);
+			free(node);
+			return (NULL);
+		}
+		node->argv[node->argc] = NULL;
+		cur = cur->next;
+	}
+    // リダイレクト演算子がある間、redirsに追加
+	while (peek_redir_op(cur))
+	{
+		node->redir_count++;
+		node->redirs = ft_realloc(node->redirs, sizeof(t_redir *)
+        * node->redir_count, sizeof(t_redir *)
+				* (node->redir_count + 1));
+		node->redirs[node->redir_count - 1] = parse_redir(&cur, cur);
+        if (!node->redirs[node->redir_count - 1])
+        {
+            free(node->redirs[node->redir_count - 1]);
+            free(node->redirs);
+            free(node);
+            return (NULL);
+        }
+        node->redirs[node->redir_count] = NULL;
+        cur = cur->next;
+	}
+	if (node->argc == 0 && node->redir_count == 0)
+	{
+		ft_dprintf(STDERR_FILENO, "parse error (parse_command)\n");
+		free(node);
+		return (NULL);
+	}
+	*rest = cur;
+	return (node);
+}
+
+// / トークンを解析してASTを生成
+t_node	*parse_line(t_token **rest, t_token *cur)
+{
+	t_node	*node;
+	t_node	*right;
+
+	node = parse_command(&cur, cur);
+	if (!node)
+		return (NULL);
+	while (consume(&cur, cur, "|"))
+	{
+        // 右側のコマンドを解析
+		right = parse_command(&cur, cur);
+		if (!right)
+			return (NULL);
+        // パイプノードを作成し、それを根として左右のノードを接続
+		node = new_pipe_node(node, right);
+		if (!node)
+			return (NULL);
+	}
+	*rest = cur;
+	return (node);
+}
+
+// 構文解析
+int	parse(t_token *tokens, t_node **ast)
+{
+	// トークンの残り（tokensをfreeできるように別変数で管理）
+	t_token	*rest;
+
+	// トークンの先頭をrestに設定
+	rest = tokens;
+	// トークンを解析してASTを生成
+	*ast = parse_line(&rest, tokens);
+	if (!(*ast))
+		return (-1);
+	// 残りのトークンがEOFでない場合はエラー
+	if (rest->type != TK_EOF)
+	{
+		ft_dprintf(STDERR_FILENO,
+					"parse error: extra token after valid input: \
+			%s\n",
+					rest->str);
+		return (-1);
+	}
+	return (0);
+}

--- a/srcs/parsing/peek.c
+++ b/srcs/parsing/peek.c
@@ -1,0 +1,23 @@
+#include "minishell.h"
+
+// トークンがTK_WORDかどうか確認
+int	peek_word(t_token *token)
+{
+	if (token->type == TK_WORD)
+		return (1);
+	return (0);
+}
+
+// トークンがリダイレクト演算子かどうか確認
+int	peek_redir_op(t_token *token)
+{
+	// トークンが予約語でなければエラー
+	if (token->type != TK_RESERVED)
+		return (0);
+	// トークンがリダイレクト記号かどうか
+	if (ft_strncmp(token->str, ">>", 3) == 0 || ft_strncmp(token->str, ">",
+			2) == 0 || ft_strncmp(token->str, "<<", 3) == 0
+		|| ft_strncmp(token->str, "<", 2) == 0)
+		return (1);
+	return (0);
+}

--- a/srcs/utils/cmp.c
+++ b/srcs/utils/cmp.c
@@ -1,2 +1,0 @@
-#include "minishell.h"
-

--- a/srcs/utils/cmp.c
+++ b/srcs/utils/cmp.c
@@ -1,0 +1,2 @@
+#include "minishell.h"
+

--- a/srcs/utils/free.c
+++ b/srcs/utils/free.c
@@ -28,7 +28,6 @@ void	free_tokens(t_token *token)
 		free(token);
 		token = tmp;
 	}
-	token = NULL;
 }
 
 void	free_redirs(t_redir **redirs)

--- a/srcs/utils/free.c
+++ b/srcs/utils/free.c
@@ -19,6 +19,8 @@ void	free_tokens(t_token *token)
 {
 	t_token	*tmp;
 
+	if (!token)
+		return ;
 	while (token)
 	{
 		tmp = token->next;
@@ -29,9 +31,43 @@ void	free_tokens(t_token *token)
 	token = NULL;
 }
 
+void	free_redirs(t_redir **redirs)
+{
+	int	i;
+
+	if (!redirs)
+		return ;
+	i = 0;
+	while (redirs[i])
+	{
+		free(redirs[i]->str);
+		free(redirs[i]);
+		i++;
+	}
+	free(redirs);
+}
+
+void	free_ast(t_node *ast)
+{
+	if (!ast)
+		return ;
+	if (ast->lhs)
+		free_ast(ast->lhs);
+	if (ast->rhs)
+		free_ast(ast->rhs);
+	if (ast->argv)
+		free_2d_array(ast->argv);
+	if (ast->redirs)
+		free_redirs(ast->redirs);
+	free(ast);
+}
+
 void	free_shell(t_shell *shell)
 {
-	free_tokens(shell->tokens);
+	if (shell->tokens)
+		free_tokens(shell->tokens);
+	if (shell->ast)
+		free_ast(shell->ast);
 	if (shell->envp_cp)
 		free_2d_array(shell->envp_cp);
 }


### PR DESCRIPTION
- `|` 記号とそれ以外（コマンド・オプション・引数・リダイレクト）をノードとして分けた木構造（AST）を構築
- `|` の前後に何もない場合、またはリダイレクト記号の直後に何もない場合に `syntax error` を検出してエラー出力

### TODO
- メモリリークあるため修正予定
- `syntax error` メッセージが固定になっているため、テストケースを追加して適切なエラーメッセージを返せるように改善する必要がありそう

### 補足
EBNFで記述した規則
```
line    = command ( "|" command )*
command = prefix ( redir )*
prefix  = word ( word )*
redir   = redir_op word
redir_op = "<" | ">" | ">>" | "<<"
以下略
```