### PR TITLE
空白文字判定をスペースとタブだけに変更

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -122,7 +122,7 @@ int					is_two_metachar(char *p);
 int					is_single_metachar(char *p);
 int					is_two_metachar(char *p);
 int					is_quote(char *p);
-int					is_space(char c);
+int					is_blank(char c);
 
 // parsing
 void				parse(t_token *tokens, t_node **ast);

--- a/srcs/tokenization/is_blank.c
+++ b/srcs/tokenization/is_blank.c
@@ -1,6 +1,6 @@
 #include "minishell.h"
 
-int	is_space(char c)
+int	is_blank(char c)
 {
 	if (c == ' ' || c == '\t')
 		return (1);

--- a/srcs/tokenization/is_space.c
+++ b/srcs/tokenization/is_space.c
@@ -2,8 +2,7 @@
 
 int	is_space(char c)
 {
-	if (c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f'
-		|| c == '\r')
+	if (c == ' ' || c == '\t')
 		return (1);
 	return (0);
 }

--- a/srcs/tokenization/tokenize.c
+++ b/srcs/tokenization/tokenize.c
@@ -40,7 +40,7 @@ void	tokenize(char *line, t_token **tokens)
 	while (*p)
 	{
 		// 空白文字をスキップ
-		if (is_space(*p))
+		if (is_blank(*p))
 			p++;
 		// 2文字のメタ文字をトークン化
 		else if (is_two_metachar(p))
@@ -71,7 +71,7 @@ void	tokenize(char *line, t_token **tokens)
 		else
 		{
 			start = p;
-			while (*p && !is_space(*p) && !is_two_metachar(p)
+			while (*p && !is_blank(*p) && !is_two_metachar(p)
 				&& !is_single_metachar(p))
 			{
 				if (is_quote(p))


### PR DESCRIPTION
fix #26 

`is_space()`での判定を`isspace(3)`の文字すべてから、スペースとタブだけに変更しました。
あわせて関数名とファイル名を`is_blank`に変更しました。