### PR TITLE
ファイル非存在時のエラーメッセージを修正

### DIFF
--- a/srcs/main.c
+++ b/srcs/main.c
@@ -21,10 +21,7 @@ int	main(int argc, char **argv, char **envp)
         init_signals();
 		input = readline("minishell$ ");
 		if (!input)
-        {
-            write(STDOUT_FILENO, "exit\n", 5);
 			break ;
-        }
 		if (*input)
 			add_history(input);
         // TODO: それぞれエラー時の処理を追加
@@ -42,7 +39,7 @@ int	main(int argc, char **argv, char **envp)
 		shell->ast = NULL;
 	}
 	free_shell(shell);
-	exit(0);
+	ft_exit(1, NULL);
 }
 
 // int	main(void)

--- a/srcs/redirection/redirect.c
+++ b/srcs/redirection/redirect.c
@@ -29,7 +29,7 @@ int	apply_io_redir(t_redir *redir, int flags, int std_fd)
 	fd = open(redir->str, flags, 0644);
 	if (fd < 0)
 	{
-		perror("minishell");
+		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", redir->str, strerror(errno));
 		return (1);
 	}
 	if (dup2(fd, std_fd) == -1)

--- a/srcs/redirection/redirect.c
+++ b/srcs/redirection/redirect.c
@@ -29,7 +29,8 @@ int	apply_io_redir(t_redir *redir, int flags, int std_fd)
 	fd = open(redir->str, flags, 0644);
 	if (fd < 0)
 	{
-		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", redir->str, strerror(errno));
+		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n",
+			redir->str, strerror(errno));
 		return (1);
 	}
 	if (dup2(fd, std_fd) == -1)


### PR DESCRIPTION
fix #40 
リダイレクトにおいて、指定されたファイルが存在しなかった場合のエラーメッセージの出力を修正。
ファイル名も表示されるようにした。