### PR TITLE
builtinの返り値は1でも終了しない

### DIFF
--- a/srcs/execution/exec_builtin.c
+++ b/srcs/execution/exec_builtin.c
@@ -62,8 +62,7 @@ int	process_builtin_direct(t_node *node)
 		restore_std_fds(stashed_stdin, stashed_stdout);
 		return (1);
 	}
-	if (exec_builtin_cmd(node) == 1)
-		return (1);
+	exec_builtin_cmd(node);
 	if (restore_std_fds(stashed_stdin, stashed_stdout) != 0)
 		return (1);
 	return (0);


### PR DESCRIPTION
#66 からmergeすること.
タイトルの通り.
問題となっていたprocess_builtin_directでbuiltinの実行値が１でない場合１が返っていた箇所を
そもそも返り値を確認しないよう修正。
ぷち
