### PR TITLE
メモリーリーク修正

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/01 03:06:23 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/06/01 18:00:28 by yumiyao          ###   ########.fr       */
+/*   Updated: 2025/07/13 12:40:21 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -271,7 +271,6 @@ int								event(void);
 int								ft_split_len(char **split);
 void							*ft_malloc(size_t size);
 void							interpret(t_shell *shell);
-void							exit_shell(int print);
 void							finish_loop(t_shell *shell);
 char							**get_longer_split(char **split, char *new,
 									int len);

--- a/srcs/builtin/env.c
+++ b/srcs/builtin/env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   env.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/17 00:47:01 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/05/31 21:38:38 by yumiyao          ###   ########.fr       */
+/*   Updated: 2025/07/13 11:59:41 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,6 +72,7 @@ int	env(int argc, char **argv)
 			inner_exit(125);
 		while (envp[i])
 			ft_dprintf(STDOUT_FILENO, "%s\n", envp[i++]);
+		free(envp);
 	}
 	return (EXIT_SUCCESS);
 }

--- a/srcs/builtin/inner_exit.c
+++ b/srcs/builtin/inner_exit.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   inner_exit.c                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/31 21:09:05 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/05/31 21:10:59 by yumiyao          ###   ########.fr       */
+/*   Updated: 2025/07/13 12:07:04 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 
 void	inner_exit(int status)
 {
+	rl_clear_history();
 	ft_env(ENV_DEL_ALL, NULL);
 	sh_op(SH_DEL, NULL);
 	exit(status);

--- a/srcs/execution/exec_cmd.c
+++ b/srcs/execution/exec_cmd.c
@@ -12,18 +12,18 @@ void	exec_if_relative_path(char **cmds, char **envp)
 				execve(cmds[0], cmds, envp);
 				ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
 					strerror(errno));
-				free_2d_array(cmds);
-				exit(1);
+				free(envp);
+				inner_exit(1);
 			}
 			ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
 				strerror(errno));
-			free_2d_array(cmds);
-			exit(126);
+			free(envp);
+			inner_exit(126);
 		}
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
 			strerror(errno));
-		free_2d_array(cmds);
-		exit(127);
+		free(envp);
+		inner_exit(127);
 	}
 }
 
@@ -37,17 +37,17 @@ void	exec_if_absolute_path(char **cmds, char **envp)
 			execve(cmds[0], cmds, envp);
 			ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
 				strerror(errno));
-			free_2d_array(cmds);
-			exit(1);
+			free(envp);
+			inner_exit(1);
 		}
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
 			strerror(errno));
-		free_2d_array(cmds);
-		exit(126);
+		free(envp);
+		inner_exit(126);
 	}
 	ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0], strerror(errno));
-	free_2d_array(cmds);
-	exit(127);
+	free(envp);
+	inner_exit(127);
 }
 
 // コマンド実行
@@ -65,13 +65,14 @@ void	exec_cmd(char **cmds, char **envp)
 	cmd_path = resolve_cmd_path(cmds[0], path_env, &status);
 	if (!cmd_path)
 	{
-		free_2d_array(cmds);
-		exit(status);
+		free(envp);
+		inner_exit(status);
 	}
 	set_exec_sigint();
 	set_exec_sigquit();
 	execve(cmd_path, cmds, envp);
 	ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0], strerror(errno));
-	free_2d_array(cmds);
-	exit(1);
+	free(envp);
+	free(cmd_path);
+	inner_exit(1);
 }

--- a/srcs/execution/prepare.c
+++ b/srcs/execution/prepare.c
@@ -24,7 +24,7 @@ void	prepare_pipe_child(t_node *node, int count)
 		if (dup2(node->in_fd, STDIN_FILENO) == -1)
 		{
 			ft_dprintf(STDERR_FILENO, "minishell: dup2: %s\n", strerror(errno));
-			exit(1);
+			inner_exit(1);
 		}
 		close(node->in_fd);
 	}
@@ -34,7 +34,7 @@ void	prepare_pipe_child(t_node *node, int count)
 		if (dup2(node->pipefd[1], STDOUT_FILENO) == -1)
 		{
 			ft_dprintf(STDERR_FILENO, "minishell: dup2: %s\n", strerror(errno));
-			exit(1);
+			inner_exit(1);
 		}
 		close(node->pipefd[1]);
 		close(node->pipefd[0]);

--- a/srcs/interpret.c
+++ b/srcs/interpret.c
@@ -1,17 +1,11 @@
 #include "minishell.h"
 
-void	exit_shell(int print)
-{
-	rl_clear_history();
-	ft_exit(1, NULL, print);
-}
-
 int	handle_stage_ret(int ret)
 {
 	if (ret == 1)
 	{
 		sh_stat(ST_SET, 1);
-		exit_shell(0);
+		ft_exit(1, NULL, 0);
 		return (1);
 	}
 	else if (ret != 0)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -11,7 +11,10 @@ int	main(int argc, char **argv, char **envp)
 	rl_event_hook = event;
 	g_sig_received = 0;
 	if (init(envp) < 0)
+	{
+		rl_clear_history();
 		exit(1);
+	}
 	shell = sh_op(SH_GET, NULL);
 	while (1)
 	{
@@ -24,6 +27,6 @@ int	main(int argc, char **argv, char **envp)
 		interpret(shell);
 		finish_loop(shell);
 	}
-	exit_shell(1);
+	ft_exit(1, NULL, 1);
 	return (0);
 }

--- a/srcs/signal/sigint.c
+++ b/srcs/signal/sigint.c
@@ -20,7 +20,7 @@ void	set_exec_sigint(void)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: "
 			"sigaction: %s\n", strerror(errno));
-		exit(1);
+		inner_exit(1);
 	}
 }
 
@@ -36,6 +36,6 @@ void	set_main_sigint(void)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: "
 			"sigaction: %s\n", strerror(errno));
-		exit(1);
+		inner_exit(1);
 	}
 }

--- a/srcs/signal/sigquit.c
+++ b/srcs/signal/sigquit.c
@@ -12,7 +12,7 @@ void	set_exec_sigquit(void)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: "
 			"sigaction: %s\n", strerror(errno));
-		exit(1);
+		inner_exit(1);
 	}
 }
 
@@ -28,6 +28,6 @@ void	set_main_sigquit(void)
 	{
 		ft_dprintf(STDERR_FILENO, "minishell: "
 			"sigaction: %s\n", strerror(errno));
-		exit(1);
+		inner_exit(1);
 	}
 }


### PR DESCRIPTION
## 変更点
- 直接`exit`を呼び出している箇所を`inner_exit()`に置き換え
- built-inのenvコマンドのリーク解消
- `exit_shell()`関数を削除して直接`ft_exit()`を呼び出しに変更

## 問題点
add_historyのリークが残っています...（still reachableですが...）
```
==1967511== 4,016 bytes in 1 blocks are still reachable in loss record 41 of 63
==1967511==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1967511==    by 0x48AABAC: xmalloc (in /usr/lib/x86_64-linux-gnu/libreadline.so.8.1)
==1967511==    by 0x48A3FD6: add_history (in /usr/lib/x86_64-linux-gnu/libreadline.so.8.1)
==1967511==    by 0x401566: main (main.c:26)
```