### PR TITLE
Norm合わせ

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/01 03:06:23 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/07/15 22:42:46 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 13:00:54 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,6 @@
 # include <readline/readline.h>
 # include <signal.h>
 # include <stdbool.h>
-# include <stdio.h>
 # include <stdlib.h>
 # include <sys/stat.h>
 # include <sys/types.h>

--- a/srcs/builtin/pwd.c
+++ b/srcs/builtin/pwd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   pwd.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/16 01:29:37 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/05/27 04:13:57 by yumiyao          ###   ########.fr       */
+/*   Updated: 2025/07/16 13:07:58 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,7 @@ int	is_pwd_error(int argc, char **argv)
 {
 	if (argc == 1)
 		return (0);
-	if (argv[1][0] != '-' || strncmp(argv[1], "--", 3) == 0)
+	if (argv[1][0] != '-' || ft_strncmp(argv[1], "--", 3) == 0)
 		return (0);
 	if (argv[1][1] == '\0')
 		return (0);

--- a/srcs/utils/ft_union.c
+++ b/srcs/utils/ft_union.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_union.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/22 14:02:36 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/05/22 14:03:00 by yumiyao          ###   ########.fr       */
+/*   Updated: 2025/07/16 13:07:31 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,7 @@ char	*ft_union(char **split, char delim)
 	while (split[i])
 	{
 		rtn[len++] = delim;
-		tmp_len = strlen(split[i]);
+		tmp_len = ft_strlen(split[i]);
 		ft_strlcpy(&(rtn[len]), split[i++], tmp_len + 1);
 		len += tmp_len;
 	}


### PR DESCRIPTION
- 未使用のヘッダーファイルのインクルードを削除（stdio.h）
- 使用禁止関数の置き換え（strlen, strncmp）