### PR TITLE
パイプ記号の重複出力を修正

### DIFF
--- a/srcs/parsing/append_redir.c
+++ b/srcs/parsing/append_redir.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/15 17:26:37 by stakada           #+#    #+#             */
-/*   Updated: 2025/07/15 17:26:58 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 13:47:42 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,6 @@ static t_redir	**get_new_redirs(t_node *node, t_token **cur, int *ret)
 	if (!redirs[node->redir_count - 1])
 	{
 		free(redirs);
-		*ret = -1;
 		return (NULL);
 	}
 	redirs[node->redir_count] = NULL;

--- a/srcs/parsing/consume.c
+++ b/srcs/parsing/consume.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/15 15:07:41 by stakada           #+#    #+#             */
-/*   Updated: 2025/07/15 15:07:47 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 13:46:06 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,7 +31,7 @@ int	consume_word(t_token **rest, char **redir_str)
 	}
 	(*redir_str) = ft_strdup(cur->str);
 	if (!(*redir_str))
-		return (1);
+		return (-1);
 	*rest = cur->next;
 	return (0);
 }

--- a/srcs/parsing/parse_cmd.c
+++ b/srcs/parsing/parse_cmd.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/15 16:32:55 by stakada           #+#    #+#             */
-/*   Updated: 2025/07/15 17:26:52 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 14:06:51 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,7 @@
 
 static t_node	*check_syntax(t_node *node, int *ret)
 {
-	if (node->argc == 0 && node->redir_count == 0)
+	if (*ret == 0 && node->argc == 0 && node->redir_count == 0)
 	{
 		ft_dprintf(STDERR_FILENO,
 			"minishell: syntax error near unexpected token `|'\n");


### PR DESCRIPTION
`echo hi | < |`のように2回パイプ記号がある場合でも、syntax error出力が1回のみになるよう修正