### PR TITLE
ディレクトリを実行しようとした場合のエラー出力を修正

### DIFF
--- a/srcs/execution/exec_cmd.c
+++ b/srcs/execution/exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/15 14:23:51 by stakada           #+#    #+#             */
-/*   Updated: 2025/07/16 16:07:41 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 16:12:11 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,51 +19,39 @@ static void	error_and_exit(char *cmd, int exit_code, char **envp)
 	inner_exit(exit_code);
 }
 
-void	exec_if_relative_path(char **cmds, char **envp)
+static void	check_executable_or_exit(char *cmd, char **envp)
 {
 	struct stat	statbuf;
 
-	if (ft_strncmp(cmds[0], "./", 2) == 0 || ft_strncmp(cmds[0], "../", 3) == 0)
-	{
-		if (access(cmds[0], F_OK) != 0)
-			error_and_exit(cmds[0], 127, envp);
-		if (stat(cmds[0], &statbuf) != 0)
-			error_and_exit(cmds[0], 126, envp);
-		if (!S_ISREG(statbuf.st_mode) || access(cmds[0], X_OK) != 0)
-		{
-			if (S_ISDIR(statbuf.st_mode))
-				ft_dprintf(STDERR_FILENO, "minishell: %s: Is a directory\n",
-					cmds[0]);
-			else
-				ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
-					strerror(errno));
-			free(envp);
-			inner_exit(126);
-		}
-		execve(cmds[0], cmds, envp);
-		error_and_exit(cmds[0], 1, envp);
-	}
-}
-
-void	exec_if_absolute_path(char **cmds, char **envp)
-{
-	struct stat	statbuf;
-
-	if (access(cmds[0], F_OK) != 0)
-		error_and_exit(cmds[0], 127, envp);
-	if (stat(cmds[0], &statbuf) != 0)
-		error_and_exit(cmds[0], 126, envp);
-	if (!S_ISREG(statbuf.st_mode) || access(cmds[0], X_OK) != 0)
+	if (access(cmd, F_OK) != 0)
+		error_and_exit(cmd, 127, envp);
+	if (stat(cmd, &statbuf) != 0)
+		error_and_exit(cmd, 126, envp);
+	if (!S_ISREG(statbuf.st_mode) || access(cmd, X_OK) != 0)
 	{
 		if (S_ISDIR(statbuf.st_mode))
-			ft_dprintf(STDERR_FILENO, "minishell: %s: Is a directory\n",
-				cmds[0]);
+			ft_dprintf(STDERR_FILENO, "minishell: %s: Is a directory\n", cmd);
 		else
-			ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
+			ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmd,
 				strerror(errno));
 		free(envp);
 		inner_exit(126);
 	}
+}
+
+void	exec_if_relative_path(char **cmds, char **envp)
+{
+	if (!(ft_strncmp(cmds[0], "./", 2) == 0 || ft_strncmp(cmds[0], "../",
+				3) == 0))
+		return ;
+	check_executable_or_exit(cmds[0], envp);
+	execve(cmds[0], cmds, envp);
+	error_and_exit(cmds[0], 1, envp);
+}
+
+void	exec_if_absolute_path(char **cmds, char **envp)
+{
+	check_executable_or_exit(cmds[0], envp);
 	execve(cmds[0], cmds, envp);
 	error_and_exit(cmds[0], 1, envp);
 }

--- a/srcs/execution/exec_cmd.c
+++ b/srcs/execution/exec_cmd.c
@@ -6,58 +6,53 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/15 14:23:51 by stakada           #+#    #+#             */
-/*   Updated: 2025/07/15 14:24:14 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 16:03:35 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+static void	error_and_exit(char *cmd, int exit_code, char **envp)
+{
+	ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmd, strerror(errno));
+	free(envp);
+	inner_exit(exit_code);
+}
+
 void	exec_if_relative_path(char **cmds, char **envp)
 {
+	struct stat	statbuf;
+
 	if (ft_strncmp(cmds[0], "./", 2) == 0 || ft_strncmp(cmds[0], "../", 3) == 0)
 	{
-		if (access(cmds[0], F_OK) == 0)
+		if (access(cmds[0], F_OK) != 0)
+			error_and_exit(cmds[0], 127, envp);
+		if (stat(cmds[0], &statbuf) != 0)
+			error_and_exit(cmds[0], 126, envp);
+		if (!S_ISREG(statbuf.st_mode) || access(cmds[0], X_OK) != 0)
 		{
-			if (access(cmds[0], X_OK) == 0)
-			{
-				execve(cmds[0], cmds, envp);
+			if (S_ISDIR(statbuf.st_mode))
+				ft_dprintf(STDERR_FILENO, "minishell: %s: Is a directory\n",
+					cmds[0]);
+			else
 				ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
 					strerror(errno));
-				free(envp);
-				inner_exit(1);
-			}
-			ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
-				strerror(errno));
 			free(envp);
 			inner_exit(126);
 		}
-		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
-			strerror(errno));
-		free(envp);
-		inner_exit(127);
+		execve(cmds[0], cmds, envp);
+		error_and_exit(cmds[0], 1, envp);
 	}
 }
 
 void	exec_if_absolute_path(char **cmds, char **envp)
 {
-	if (access(cmds[0], F_OK) == 0)
-	{
-		if (access(cmds[0], X_OK) == 0)
-		{
-			execve(cmds[0], cmds, envp);
-			ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
-				strerror(errno));
-			free(envp);
-			inner_exit(1);
-		}
-		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
-			strerror(errno));
-		free(envp);
-		inner_exit(126);
-	}
-	ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0], strerror(errno));
-	free(envp);
-	inner_exit(127);
+	if (access(cmds[0], F_OK) != 0)
+		error_and_exit(cmds[0], 127, envp);
+	if (access(cmds[0], X_OK) != 0)
+		error_and_exit(cmds[0], 126, envp);
+	execve(cmds[0], cmds, envp);
+	error_and_exit(cmds[0], 1, envp);
 }
 
 void	exec_cmd(char **cmds, char **envp)

--- a/srcs/execution/exec_cmd.c
+++ b/srcs/execution/exec_cmd.c
@@ -6,7 +6,7 @@
 /*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/15 14:23:51 by stakada           #+#    #+#             */
-/*   Updated: 2025/07/16 16:03:35 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 16:07:41 by stakada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,10 +47,23 @@ void	exec_if_relative_path(char **cmds, char **envp)
 
 void	exec_if_absolute_path(char **cmds, char **envp)
 {
+	struct stat	statbuf;
+
 	if (access(cmds[0], F_OK) != 0)
 		error_and_exit(cmds[0], 127, envp);
-	if (access(cmds[0], X_OK) != 0)
+	if (stat(cmds[0], &statbuf) != 0)
 		error_and_exit(cmds[0], 126, envp);
+	if (!S_ISREG(statbuf.st_mode) || access(cmds[0], X_OK) != 0)
+	{
+		if (S_ISDIR(statbuf.st_mode))
+			ft_dprintf(STDERR_FILENO, "minishell: %s: Is a directory\n",
+				cmds[0]);
+		else
+			ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", cmds[0],
+				strerror(errno));
+		free(envp);
+		inner_exit(126);
+	}
 	execve(cmds[0], cmds, envp);
 	error_and_exit(cmds[0], 1, envp);
 }


### PR DESCRIPTION
`minishell$ ./dir`のようにディレクトリを実行しようとした場合のエラー出力を修正