### PR TITLE
export とtypoの修正

### DIFF
--- a/srcs/builtin/cd.c
+++ b/srcs/builtin/cd.c
@@ -6,7 +6,7 @@
 /*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/07 03:40:56 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/07/16 17:54:45 by yumiyao          ###   ########.fr       */
+/*   Updated: 2025/07/16 18:57:43 by yumiyao          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ int	check_access(char *dest, char *path)
 
 	if (access(path, F_OK))
 		ft_dprintf(STDERR_FILENO, "minishell: cd: %s: No such "
-			"file or directly\n", dest);
+			"file or directory\n", dest);
 	else if (stat(path, &statbuf) != 0)
 		ft_dprintf(STDERR_FILENO, "minishell: cd: %s\n", strerror(errno));
 	else if ((((statbuf.st_mode)) & 0170000) != 0040000)

--- a/srcs/builtin/print_env.c
+++ b/srcs/builtin/print_env.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   print_env.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: stakada <stakada@student.42tokyo.jp>       +#+  +:+       +#+        */
+/*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/22 14:15:50 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/07/16 18:02:40 by stakada          ###   ########.fr       */
+/*   Updated: 2025/07/16 18:53:47 by yumiyao          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,7 +24,12 @@ void	print_env(char *env)
 		write(STDOUT_FILENO, &env[i++], 1);
 	++i;
 	write(STDOUT_FILENO, "=\"", 2);
-	write(STDOUT_FILENO, env + i, ft_strlen(env + i));
+	while (env[i])
+	{
+		if (env[i] == '"')
+			write(STDOUT_FILENO, "\\", 1);
+		write(STDOUT_FILENO, &env[i++], 1);
+	}
 	write(STDOUT_FILENO, "\"", 1);
 	write(STDOUT_FILENO, "\n", 1);
 }

--- a/srcs/env/ft_env_utils_new.c
+++ b/srcs/env/ft_env_utils_new.c
@@ -6,7 +6,7 @@
 /*   By: yumiyao <yumiyao@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/31 23:58:50 by yumiyao           #+#    #+#             */
-/*   Updated: 2025/06/01 03:31:28 by yumiyao          ###   ########.fr       */
+/*   Updated: 2025/07/16 18:48:46 by yumiyao          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,9 +37,9 @@ char	*cp_without_quoutes(char *val, int len)
 	quote = '\0';
 	while (val[i])
 	{
-		if ((quote && val[i] != quote) || !is_quote(&val[i]))
+		if (val[i] != quote)
 			rtn[j++] = val[i];
-		else if (!quote)
+		else if (!quote && is_quote(&val[i]))
 			quote = val[i];
 		else if (quote)
 			quote = '\0';
@@ -63,9 +63,9 @@ char	*rm_quotes(char *val)
 		return (NULL);
 	while (val[i])
 	{
-		if ((quote && val[i] != quote) || !is_quote(&val[i]))
+		if (val[i] != quote)
 			++len;
-		else if (!quote)
+		else if (!quote && is_quote(&val[i]))
 			quote = val[i];
 		else if (quote)
 			quote = '\0';


### PR DESCRIPTION
- exportのクォートを一番外側のみ削除する
- exportで出力時ダブルクォートはエスケープする
- cdでのタイポ